### PR TITLE
Update bits: nasm function ( removing argument "None")

### DIFF
--- a/bits/__init__.py
+++ b/bits/__init__.py
@@ -106,7 +106,7 @@ def nasm():
     os.chdir(dir)
     from bits.sw.simulator.main import init_simulator_gui
 
-    init_simulator_gui(None)
+    init_simulator_gui()
 
 
 @gui.command()


### PR DESCRIPTION
init_simulator_gui() doesn't need any arguments. 
It resolves an opening error